### PR TITLE
Add property for CORS

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1098,6 +1098,14 @@ class JupyterHub(Application):
         help="Extra settings overrides to pass to the tornado application."
     ).tag(config=True)
 
+    allowed_hosts = List(
+        Unicode(),
+        help="""List of allowed hosts.
+
+        If this config is set, JupyterHub will send 'Access-Control-Allow-Origin' for requests by the allowed host.
+        """,
+    ).tag(config=True)
+
     cleanup_servers = Bool(
         True,
         help="""Whether to shutdown single-user servers when the Hub shuts down.
@@ -2181,6 +2189,7 @@ class JupyterHub(Application):
             static_handler_class=CacheControlStaticFilesHandler,
             template_path=self.template_paths,
             template_vars=self.template_vars,
+            allowed_hosts=self.allowed_hosts,
             jinja2_env=jinja_env,
             version_hash=version_hash,
             subdomain_host=self.subdomain_host,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -229,7 +229,9 @@ class BaseHandler(RequestHandler):
         origin = self.request.headers.get('Origin', None)
         if origin is None:
             return False
-        domain = origin.split(':')[0] if ':' in origin else origin
+        domain = urlparse(origin).netloc
+        if ':' in domain:
+            domain = domain.split(':')[0]
         return domain in allowed_hosts
 
     # ---------------------------------------------------------------

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -214,9 +214,23 @@ class BaseHandler(RequestHandler):
             self.set_header(
                 'Access-Control-Allow-Headers', 'accept, content-type, authorization'
             )
+        if self._is_allowed_request():
+            self.set_header(
+                'Access-Control-Allow-Origin', self.request.headers['Origin']
+            )
         if 'Content-Security-Policy' not in headers:
             self.set_header('Content-Security-Policy', self.content_security_policy)
         self.set_header('Content-Type', self.get_content_type())
+
+    def _is_allowed_request(self):
+        allowed_hosts = self.settings.get('allowed_hosts', [])
+        if allowed_hosts is None or len(allowed_hosts) == 0:
+            return False
+        origin = self.request.headers.get('Origin', None)
+        if origin is None:
+            return False
+        domain = origin.split(':')[0] if ':' in origin else origin
+        return domain in allowed_hosts
 
     # ---------------------------------------------------------------
     # Login and cookie-related

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1684,6 +1684,41 @@ async def test_options(app):
     r = await api_request(app, 'users', method='options')
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
+    assert 'Access-Control-Allow-Origin' not in r.headers
+
+
+async def test_options_allowed_hosts(app):
+    app.allowed_hosts.append('some.host')
+    r = await api_request(app, 'users', method='options', headers={
+        'Origin': 'some.host'
+    })
+    r.raise_for_status()
+    assert 'Access-Control-Allow-Headers' in r.headers
+    assert 'Access-Control-Allow-Origin' in r.headers
+    assert r.headers['Access-Control-Allow-Origin'] == 'some.host'
+
+    r = await api_request(app, 'users', method='options', headers={
+        'Origin': 'some.host:8080'
+    })
+    r.raise_for_status()
+    assert 'Access-Control-Allow-Headers' in r.headers
+    assert 'Access-Control-Allow-Origin' in r.headers
+    assert r.headers['Access-Control-Allow-Origin'] == 'some.host:8080'
+
+    r = await api_request(app, 'users', method='options', headers={
+        'Origin': 'another.host'
+    })
+    r.raise_for_status()
+    assert 'Access-Control-Allow-Headers' in r.headers
+    assert 'Access-Control-Allow-Origin' not in r.headers
+
+    app.allowed_hosts.remove('some.host')
+    r = await api_request(app, 'users', method='options', headers={
+        'Origin': 'some.host'
+    })
+    r.raise_for_status()
+    assert 'Access-Control-Allow-Headers' in r.headers
+    assert 'Access-Control-Allow-Origin' not in r.headers
 
 
 async def test_bad_json_body(app):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1689,33 +1689,33 @@ async def test_options(app):
 
 async def test_options_allowed_hosts(app):
     app.allowed_hosts.append('some.host')
-    r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'http://some.host'
-    })
+    r = await api_request(
+        app, 'users', method='options', headers={'Origin': 'http://some.host'}
+    )
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' in r.headers
     assert r.headers['Access-Control-Allow-Origin'] == 'http://some.host'
 
-    r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'http://some.host:8080'
-    })
+    r = await api_request(
+        app, 'users', method='options', headers={'Origin': 'http://some.host:8080'}
+    )
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' in r.headers
     assert r.headers['Access-Control-Allow-Origin'] == 'http://some.host:8080'
 
-    r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'http://another.host'
-    })
+    r = await api_request(
+        app, 'users', method='options', headers={'Origin': 'http://another.host'}
+    )
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' not in r.headers
 
     app.allowed_hosts.remove('some.host')
-    r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'http://some.host'
-    })
+    r = await api_request(
+        app, 'users', method='options', headers={'Origin': 'http://some.host'}
+    )
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' not in r.headers

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1690,23 +1690,23 @@ async def test_options(app):
 async def test_options_allowed_hosts(app):
     app.allowed_hosts.append('some.host')
     r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'some.host'
+        'Origin': 'http://some.host'
     })
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' in r.headers
-    assert r.headers['Access-Control-Allow-Origin'] == 'some.host'
+    assert r.headers['Access-Control-Allow-Origin'] == 'http://some.host'
 
     r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'some.host:8080'
+        'Origin': 'http://some.host:8080'
     })
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
     assert 'Access-Control-Allow-Origin' in r.headers
-    assert r.headers['Access-Control-Allow-Origin'] == 'some.host:8080'
+    assert r.headers['Access-Control-Allow-Origin'] == 'http://some.host:8080'
 
     r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'another.host'
+        'Origin': 'http://another.host'
     })
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
@@ -1714,7 +1714,7 @@ async def test_options_allowed_hosts(app):
 
     app.allowed_hosts.remove('some.host')
     r = await api_request(app, 'users', method='options', headers={
-        'Origin': 'some.host'
+        'Origin': 'http://some.host'
     })
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers


### PR DESCRIPTION
JupyterHubのAPIを外部ウェブサイトから呼び出し可能にするため、以下の追加を行いました。(GRDM-23355)

* CORS(Cross-Origin Resource Sharing)設定の追加

CORS設定としては以下の設定項目を追加しています。

* allowed_hosts: List ... APIアクセスを許可するホスト(ドメイン名)の一覧。このパラメータを指定すると、JupyterHubは 'Access-Control-Allow-Origin' をそのホストからのアクセスに対して送出する