### PR TITLE
[GRDM-28115] 戻り先リンク表示への対応

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -48,6 +48,9 @@ class RootHandler(BaseHandler):
             url = self.get_next_url(user)
         else:
             url = url_concat(self.settings["login_url"], dict(next=self.request.uri))
+            return_on_error = self.get_argument('return_on_error', None)
+            if return_on_error:
+                url = url_concat(url, dict(return_on_error=return_on_error))
         self.redirect(url)
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -952,6 +952,9 @@ class HubAuthenticated:
             # add state argument to OAuth url
             state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
             login_url = url_concat(login_url, {'state': state})
+        return_on_error = self.get_argument('return_on_error', None)
+        if return_on_error:
+            login_url = url_concat(login_url, {'return_on_error': return_on_error})
         # temporary override at setting level,
         # to allow any subclass overrides of get_login_url to preserve their effect
         # for example, APIHandler raises 403 to prevent redirects

--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -62,3 +62,8 @@
     }
   }
 }
+
+#return-on-error {
+  padding: 1em;
+  text-align: right;
+}

--- a/share/jupyterhub/templates/404.html
+++ b/share/jupyterhub/templates/404.html
@@ -7,6 +7,8 @@
 {% block script %}
 {{ super() }}
 <script>
-  showReturnOnError();
+  $(document).ready(function() {
+    showReturnOnError();
+  });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/404.html
+++ b/share/jupyterhub/templates/404.html
@@ -3,3 +3,10 @@
 {% block error_detail %}
 <p>Jupyter has lots of moons, but this is not one...</p>
 {% endblock %}
+
+{% block script %}
+{{ super() }}
+<script>
+  showReturnOnError();
+</script>
+{% endblock %}

--- a/share/jupyterhub/templates/error.html
+++ b/share/jupyterhub/templates/error.html
@@ -60,5 +60,8 @@
     }
 
     _remove_redirects_from_url();
+    $(document).ready(function() {
+      showReturnOnError();
+    });
   </script>
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -112,6 +112,8 @@ $('form').submit((e) => {
 });
 </script>
 <script>
-  showReturnOnError();
+  $(document).ready(function() {
+    showReturnOnError();
+  });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -111,4 +111,7 @@ $('form').submit((e) => {
   form.find('.feedback-widget>*').toggleClass('fa-pulse');
 });
 </script>
+<script>
+  showReturnOnError();
+</script>
 {% endblock %}

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -188,8 +188,24 @@
 
 {% block script %}
   <script>
+    function getReturnOnErrorURL(searchParams) {
+      const returnOnError = searchParams.get('return_on_error');
+      if (returnOnError) {
+        return returnOnError;
+      }
+      const nextURLString = searchParams.get('next');
+      if (!nextURLString) {
+        return null;
+      }
+      const nextURL = new URL(nextURLString, window.location.href);
+      if (!nextURL.search) {
+        return null;
+      }
+      return getReturnOnErrorURL(nextURL.searchParams);
+    }
+
     function showReturnOnError() {
-      const returnOnError = (new URLSearchParams(window.location.search)).get('return_on_error');
+      const returnOnError = getReturnOnErrorURL(new URLSearchParams(window.location.search));
       if (!returnOnError) {
         return;
       }

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -187,6 +187,19 @@
 {% endcall %}
 
 {% block script %}
+  <script>
+    function showReturnOnError() {
+      const returnOnError = (new URLSearchParams(window.location.search)).get('return_on_error');
+      if (!returnOnError) {
+        return;
+      }
+      $('#return-on-error a').attr('href', returnOnError);
+      $('#return-on-error').show();
+    }
+  </script>
+  <div id="return-on-error" style="display: none;">
+    <a href="#">Back to the previous page</a>
+  </div>
 {% endblock %}
 
 </body>


### PR DESCRIPTION
エラー発生時のフロー改善として、JupyterHubの各ページに `return_on_error` パラメータを設定可能にしました。
JupyterHubはこのパラメータが指定されていた場合、その文字列をURLとして解釈して戻るリンクを表示するようになります。