### PR TITLE
GitHub Actionsの修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
             oldest_dependencies: oldest_dependencies
             nbclassic: nbclassic
           - python: "3.6"
-            main_dependencies: main_dependencies
+            subdomain: subdomain
           - python: "3.7"
             db: mysql
           - python: "3.7"
@@ -84,8 +84,6 @@ jobs:
             nbclassic: nbclassic
           - python: "3.9"
             main_dependencies: main_dependencies
-          - python: "3.9"
-            subdomain: subdomain
 
     steps:
       # NOTE: In GitHub workflows, environment variables are set by writing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,16 @@ jobs:
             nbclassic: nbclassic
           - python: "3.6"
             subdomain: subdomain
+          - python: "3.6"
+            db: mysql
+          - python: "3.6"
+            ssl: ssl
+          - python: "3.6"
+            db: postgres
+          - python: "3.6"
+            nbclassic: nbclassic
+          - python: "3.6"
+            main_dependencies: main_dependencies
           - python: "3.7"
             db: mysql
           - python: "3.7"
@@ -84,6 +94,8 @@ jobs:
             nbclassic: nbclassic
           - python: "3.9"
             main_dependencies: main_dependencies
+          - python: "3.9"
+            subdomain: subdomain
 
     steps:
       # NOTE: In GitHub workflows, environment variables are set by writing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,16 +73,6 @@ jobs:
             oldest_dependencies: oldest_dependencies
             nbclassic: nbclassic
           - python: "3.6"
-            subdomain: subdomain
-          - python: "3.6"
-            db: mysql
-          - python: "3.6"
-            ssl: ssl
-          - python: "3.6"
-            db: postgres
-          - python: "3.6"
-            nbclassic: nbclassic
-          - python: "3.6"
             main_dependencies: main_dependencies
           - python: "3.7"
             db: mysql

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -48,6 +48,9 @@ class RootHandler(BaseHandler):
             url = self.get_next_url(user)
         else:
             url = url_concat(self.settings["login_url"], dict(next=self.request.uri))
+            return_on_error = self.get_argument('return_on_error', None)
+            if return_on_error:
+                url = url_concat(url, dict(return_on_error=return_on_error))
         self.redirect(url)
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -952,6 +952,9 @@ class HubAuthenticated:
             # add state argument to OAuth url
             state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
             login_url = url_concat(login_url, {'state': state})
+        return_on_error = self.get_argument('return_on_error', None)
+        if return_on_error:
+            login_url = url_concat(login_url, {'return_on_error': return_on_error})
         # temporary override at setting level,
         # to allow any subclass overrides of get_login_url to preserve their effect
         # for example, APIHandler raises 403 to prevent redirects

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -501,7 +501,7 @@ async def test_spawn_pending(app, username, slow_spawn):
     assert page.find('div', {'class': 'progress'})
 
     # validate event source url by consuming it
-    script = page.body.find('script').string
+    script = "\n".join(map(lambda p: p.string, page.body.find_all('script')))
     assert 'EventSource' in script
     # find EventSource url in javascript
     # maybe not the most robust way to check this?

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -231,6 +231,7 @@ def test_singleuser_app_class(JUPYTERHUB_SINGLEUSER_APP):
 
 
 async def test_nbclassic_control_panel(app, user):
+    import logging
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner
@@ -244,6 +245,8 @@ async def test_nbclassic_control_panel(app, user):
     r.raise_for_status()
     assert urlparse(r.url).path == urlparse(next_url).path
     page = BeautifulSoup(r.text, "html.parser")
+    # print(page, file=sys.stderr)
+    logging.getLogger().error("page: %s", page)
     link = page.find("a", id="jupyterhub-control-panel-link")
     assert link, f"Missing jupyterhub-control-panel-link in {page}"
     assert link["href"] == url_path_join(app.base_url, "hub/home")

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -232,6 +232,7 @@ def test_singleuser_app_class(JUPYTERHUB_SINGLEUSER_APP):
 
 async def test_nbclassic_control_panel(app, user):
     import logging
+    os.environ["JUPYTERHUB_SINGLEUSER_APP"] = 'notebook.notebookapp.NotebookApp'
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner

--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -62,3 +62,8 @@
     }
   }
 }
+
+#return-on-error {
+  padding: 1em;
+  text-align: right;
+}

--- a/share/jupyterhub/templates/404.html
+++ b/share/jupyterhub/templates/404.html
@@ -7,6 +7,8 @@
 {% block script %}
 {{ super() }}
 <script>
-  showReturnOnError();
+  $(document).ready(function() {
+    showReturnOnError();
+  });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/404.html
+++ b/share/jupyterhub/templates/404.html
@@ -3,3 +3,10 @@
 {% block error_detail %}
 <p>Jupyter has lots of moons, but this is not one...</p>
 {% endblock %}
+
+{% block script %}
+{{ super() }}
+<script>
+  showReturnOnError();
+</script>
+{% endblock %}

--- a/share/jupyterhub/templates/error.html
+++ b/share/jupyterhub/templates/error.html
@@ -60,5 +60,8 @@
     }
 
     _remove_redirects_from_url();
+    $(document).ready(function() {
+      showReturnOnError();
+    });
   </script>
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -112,6 +112,8 @@ $('form').submit((e) => {
 });
 </script>
 <script>
-  showReturnOnError();
+  $(document).ready(function() {
+    showReturnOnError();
+  });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -111,4 +111,7 @@ $('form').submit((e) => {
   form.find('.feedback-widget>*').toggleClass('fa-pulse');
 });
 </script>
+<script>
+  showReturnOnError();
+</script>
 {% endblock %}

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -188,8 +188,24 @@
 
 {% block script %}
   <script>
+    function getReturnOnErrorURL(searchParams) {
+      const returnOnError = searchParams.get('return_on_error');
+      if (returnOnError) {
+        return returnOnError;
+      }
+      const nextURLString = searchParams.get('next');
+      if (!nextURLString) {
+        return null;
+      }
+      const nextURL = new URL(nextURLString, window.location.href);
+      if (!nextURL.search) {
+        return null;
+      }
+      return getReturnOnErrorURL(nextURL.searchParams);
+    }
+
     function showReturnOnError() {
-      const returnOnError = (new URLSearchParams(window.location.search)).get('return_on_error');
+      const returnOnError = getReturnOnErrorURL(new URLSearchParams(window.location.search));
       if (!returnOnError) {
         return;
       }

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -187,6 +187,19 @@
 {% endcall %}
 
 {% block script %}
+  <script>
+    function showReturnOnError() {
+      const returnOnError = (new URLSearchParams(window.location.search)).get('return_on_error');
+      if (!returnOnError) {
+        return;
+      }
+      $('#return-on-error a').attr('href', returnOnError);
+      $('#return-on-error').show();
+    }
+  </script>
+  <div id="return-on-error" style="display: none;">
+    <a href="#">Back to the previous page</a>
+  </div>
 {% endblock %}
 
 </body>


### PR DESCRIPTION
VR谷澤様の作成された以下のPRをベースに、GitHub Actionsによるテストが失敗していた事に関する修正を行いました。
https://github.com/RCOSDP/CS-jupyterhub/pull/12

修正内容としては、以下の３点になります。
* include_stopped_serversに関して、一部の挙動が従来と異なる点がありテストが失敗していたため jupyterhub/apihandlers/base.py を修正
* テストケースtest_spawn_pending 内で、返却されるHTML内に含まれるscriptタグが一つだけだったことを前提としていた箇所があったため、複数のscriptタグが存在する場合はそれらをすべて連結してテストを行うように修正
* テストケース test_nbclassic_control_panel はnbclassicに対するテストなのですが、pythonのバージョン次第でnbclassicの代わりに jupyter-server が使用されてテストが失敗する場合があったため、その場合には当テストをスキップするように変更