### PR TITLE
Allow username with equal sign

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -861,7 +861,7 @@ class ConfigurableHTTPProxy(Proxy):
         """
         # chp stores routes in unescaped form.
         # restore escaped-form we created it with.
-        routespec = quote(chp_path, safe='@/~')
+        routespec = quote(chp_path, safe='@/~=')
         if self.host_routing:
             # host routes don't start with /
             routespec = routespec.lstrip('/')

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -424,7 +424,7 @@ def compare_token(compare, token):
 
 def url_escape_path(value):
     """Escape a value to be used in URLs, cookies, etc."""
-    return quote(value, safe='@~')
+    return quote(value, safe='@~=')
 
 
 def url_path_join(*pieces):


### PR DESCRIPTION
ePPNから生成されたURLにイコール記号（=）が含まれる場合にJupyter サーバにアクセスすると404が返されてしまう件に関して、対応を行いました。
